### PR TITLE
Fix Murasama M1 damage never scaling with Trial Level (LegendData reset every frame)

### DIFF
--- a/Content/LegendWeapon/MurasamaLegend/MurasamaOverride.cs
+++ b/Content/LegendWeapon/MurasamaLegend/MurasamaOverride.cs
@@ -344,7 +344,7 @@ namespace CalamityOverhaul.Content.LegendWeapon.MurasamaLegend
             Item.rare = CWRID.Rarity_BurnishedAuric;
             Item.CWR().isHeldItem = true;
             Item.CWR().heldProjType = ModContent.ProjectileType<MurasamaHeld>();
-            Item.CWR().LegendData = new MuraData();
+            Item.CWR().LegendData ??= new MuraData();
             ItemMeleePrefixDic[Item.type] = true;
             ItemRangedPrefixDic[Item.type] = false;
         }


### PR DESCRIPTION
Fixes a bug where Murasama's M1 damage is permanently stuck at the base value (~16) regardless of Trial progression. Trial progress, skill unlocks, tooltip Level display, and skill projectile damage all scaled correctly, only the M1 basic slash was broken.

Reproduction (before fix)
- New world, fresh Murasama spawn: Trial 1 → 16 damage, Trial 7 → 16 damage, Trial ~25 → 20–40 damage.
- Existing save with high Trial progress: same behavior.
- Skills (Rising Dragon, Ground Smash, etc.) scale correctly.
- Tooltip shows the correct Trial count and Level.

Root cause
MurasamaOverride.SetDefaultsFunc unconditionally replaces LegendData with a fresh MuraData() on every invocation
( Item.CWR().LegendData = new MuraData(); )

This wipes Level back to 0. On its own that would be harmless (SetDefaults normally only runs once per item instance), but MuraChargeUI.Update() calls MurasamaItem.Initialize() **every frame** during the UI draw pass, and vanilla Item.Initialize() re-invokes SetDefaults(netID).

The fix

One-line change in Content/LegendWeapon/MurasamaLegend/MurasamaOverride.cs inside SetDefaultsFunc

( Item.CWR().LegendData ??= new MuraData(); )

The ??= null-coalescing assignment preserves the existing MuraData (with its Level and CompletedTrialKeys) across every re-entry of SetDefaults, while still initializing a fresh instance for genuinely new items (loot drop, cheat spawn, new inventory slot). LoadData still runs after SetDefaults, so tag-based load overrides work as before.